### PR TITLE
pass args to  parent::__call

### DIFF
--- a/src/Bican/Roles/HasRole.php
+++ b/src/Bican/Roles/HasRole.php
@@ -174,7 +174,6 @@ trait HasRole {
      * @param string $method
      * @param array $parameters
      * @return mixed
-     * @throws BadMethodCallException
      */
     public function __call($method, $parameters)
     {
@@ -197,7 +196,7 @@ trait HasRole {
             return false;
         }
 
-        throw new BadMethodCallException('Method [' . $method . '] does not exist.');
+        return parent::__call($method, $parameters);
     }
 
 }


### PR DESCRIPTION
trait was overwriting __call on EloquentModel
